### PR TITLE
chore: upgrade to OpenUI5-FHIR version 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"local-web-server": "^4.0.0"
 	},
 	"dependencies": {
-		"openui5-fhir": "^1.0.5",
+		"openui5-fhir": "^1.1.2",
 		"@openui5/sap.m": "^1.75.0",
 		"@openui5/sap.ui.core": "^1.75.0",
 		"@openui5/themelib_sap_fiori_3": "^1.75.0",


### PR DESCRIPTION
This PR upgrades to the OpenUI5-FHIR version 1.1.2