### PR TITLE
chore: deploy application to GH pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build-and-deploy-application:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v1.4.2
+      with:
+        node-version: "14.x"
+
+    - name: Install the Dependencies
+      run: npm install
+
+    - name: Build the Application
+      run: npm run build
+
+    - name: GitHub Pages action
+      uses: peaceiris/actions-gh-pages@v3.6.1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./dist

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # OpenUI5-FHIR Sample App
 This project describes how to use the famous *OpenUI5-FHIR* project to build beautiful Fiori look and feel UI5 applications based on services using the [FHIR®](https://www.hl7.org/fhir/index.html) protocol.
 
+## Live Demo
+Just visit the [live demo](http://sap-samples.github.io/openui5-fhir-sample-app) to try out the application.
+
 ## Prerequisites
 - Download and install [node.js](https://nodejs.org/en/download/)
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
 	},
 	"devDependencies": {
 		"@ui5/cli": "^2.2.6",
-		"rimraf": "^3.0.2",
 		"local-web-server": "^4.0.0"
 	},
 	"dependencies": {
@@ -27,7 +26,7 @@
 	"scripts": {
 		"serve": "ui5 serve",
 		"serve:dist": "ws --compress -d dist",
-		"build": "rimraf dist && ui5 build -a",
-		"build:self-contained": "rimraf dist && ui5 build self-contained -a"
+		"build": "ui5 build -a --clean-dest",
+		"build:self-contained": "ui5 build self-contained -a --clean-dest"
 	}
 }


### PR DESCRIPTION
This PR deploys the application to GitHub pages. With that the application can be consumed without checking out the repository.