### PR TITLE
chore(workflows): add explicit GITHUB_TOKEN permissions for least-pri…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-and-deploy-application:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - name: REUSE Compliance Check


### PR DESCRIPTION
…vilege access

dd permissions blocks to deploy and reuse-compliance workflows to follow the principle of least privilege. The build-and-deploy job requires contents and pages write access for GitHub Pages publishing, while the REUSE compliance check only needs contents read access.